### PR TITLE
fixed results width in searchresults.css #2

### DIFF
--- a/frontend/css/searchresults.css
+++ b/frontend/css/searchresults.css
@@ -77,8 +77,7 @@ p{
     justify-content: center;
 }
 .results-div{
-
-    width: 1250px;
+    flex: 1;
     height: 325px;
     margin-bottom: 15px;
     overflow: hidden;


### PR DESCRIPTION
added flex:1; to results and got rid of width to make the text fit on window